### PR TITLE
Add Laravel UI preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A curated list of awesome UIkit tools and resources. Inspired by [awesome-php](h
 
 ## Framework Integration
  - [Vuikit](https://vuikit.js.org) - Vue.js components built with UIkit
+ - [Laravel UI Preset](https://github.com/Torrix/laravel-ui-uikit) - Laravel 6 UI preset for UIkit
 
 ## CMS built with UIkit
  - [Pagekit](https://pagekit.com) - Open source PHP CMS. Backend uses UIkit. Most of the available frontend themes also use UIkit


### PR DESCRIPTION
I made a preset for Laravel 6, making it easy to build your website in UIkit instead of Laravel's default Bootstrap. Includes register/login templates, and a basic skeleton for your site.